### PR TITLE
Some initial r2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ angr_targets.egg-info/
 *pyc
 build/
 dist/
+*.swp

--- a/angr_targets/__init__.py
+++ b/angr_targets/__init__.py
@@ -9,6 +9,11 @@ try:
 except Exception as e:
     l.error("Impossible to load AvatarGDBConcreteTarget exception %s"%(e))
 
+try:
+    from .targets.r2_target import R2ConcreteTarget
+except Exception as e:
+    l.error("Impossible to load R2ConcreteTarget exception %s"%(e))
+
 '''
 try:
     from .targets.ida_target import IDAConcreteTarget

--- a/angr_targets/concrete.py
+++ b/angr_targets/concrete.py
@@ -17,7 +17,7 @@ class ConcreteTarget(object):
             :param int address: The address to read from
             :param int nbytes:  The amount number of bytes to read
             :return:        The memory read
-            :rtype: str
+            :rtype: bytes
             :raise angr.errors.ConcreteMemoryError
         """
         raise NotImplementedError()

--- a/angr_targets/memory_map.py
+++ b/angr_targets/memory_map.py
@@ -1,0 +1,19 @@
+
+class MemoryMap:
+    """
+    Describing a memory range inside the concrete
+    process.
+    """
+    def __init__(self, start_address, end_address, offset, name):
+        self.start_address = start_address
+        self.end_address = end_address
+        self.offset = offset
+        self.name = name
+
+    def __str__(self):
+        my_str = "MemoryMap[start_address: 0x%x | end_address: 0x%x | name: %s" \
+              % (self.start_address,
+                 self.end_address,
+                 self.name)
+
+        return my_str

--- a/angr_targets/target_states.py
+++ b/angr_targets/target_states.py
@@ -1,0 +1,13 @@
+
+class TargetStates(IntEnum):
+    """
+    Enum copied from avatar target
+    A simple Enum for the different states a target can be in.
+    """
+    CREATED = 0x1
+    INITIALIZED = 0x2
+    STOPPED = 0x4
+    RUNNING = 0x8
+    SYNCING = 0x10
+    EXITED = 0x20
+    NOT_RUNNING = INITIALIZED | STOPPED

--- a/angr_targets/targets/r2_target.py
+++ b/angr_targets/targets/r2_target.py
@@ -1,0 +1,259 @@
+
+import logging
+import os
+from base64 import b64encode, b64decode
+
+from angr.errors import SimConcreteMemoryError, SimConcreteRegisterError, SimConcreteBreakpointError
+
+from ..concrete import ConcreteTarget
+import r2pipe
+
+l = logging.getLogger("angr_targets.r2")
+l.setLevel(logging.DEBUG)
+
+
+class R2ConcreteTarget(ConcreteTarget):
+   
+    def __init__(self, r2):
+        self.r2 = r2
+        super(R2ConcreteTarget, self).__init__()
+
+    def exit(self):
+        self.avatar.shutdown()
+
+    def read_memory(self, address, nbytes, **kwargs):
+        """
+        Reading from memory of the target
+
+            :param int address: The address to read from
+            :param int nbytes:  The amount number of bytes to read
+            :return:        The memory read
+            :rtype: str
+            :raise angr.errors.SimMemoryError
+        """
+        try:
+            l.debug("R2ConcreteTarget read_memory at %x "%(address))
+            return ''.join(chr(x) for x in self.r2.cmdj('pxj {} @ {}'.format(nbytes, hex(address))))
+        except Exception as e:
+            l.debug("R2ConcreteTarget can't read_memory at address %x exception %s"%(address,e))
+            raise SimConcreteMemoryError("R2ConcreteTarget can't read_memory at address %x exception %s" % (address, e))
+
+
+    def write_memory(self,address, value, **kwargs):
+        """
+        Writing to memory of the target
+            :param int address:   The address from where the memory-write should start
+            :param str value:     The actual value written to memory
+            :raise angr.errors.ConcreteMemoryError
+        """
+
+        # TODO: Too much encode/decode...
+        l.debug("R2ConcreteTarget write_memory at %x value %s " %(address, value))
+        value = value.encode() # to bytes
+        try:
+            #res = self.target.write_memory(address, 1, value, raw=True)
+            self.r2.cmd("w6d {} @ {}".format(b64encode(value).decode(), hex(address)))
+            """
+            if not res:
+                l.warning("R2ConcreteTarget failed write_memory at %x value %s"%(address,value))
+                raise SimConcreteMemoryError("R2ConcreteTarget failed write_memory to address %x" % (address))
+            """
+        except Exception as e:
+            l.warning("R2ConcreteTarget write_memory at %x value %s exception %s"%(address,value,e))
+            raise SimConcreteMemoryError("R2ConcreteTarget write_memory at %x value %s exception %s" % (address, str(value), e))
+
+   
+    def read_register(self,register,**kwargs):
+        """"
+        Reads a register from the target
+            :param str register: The name of the register
+            :return: int value of the register content
+            :rtype int
+            :raise angr.errors.ConcreteRegisterError in case the register doesn't exist or any other exception
+        """
+
+        # Resolve some regs
+        if register in ['pc','sp','bp']:
+            l.debug('R2ConcreteTarget resolving %s',register)
+            register = self.r2.cmd('drn {}'.format(register)).strip()
+            l.debug('R2ConcreteTarget resolved to %s', register)
+
+        try:
+            l.debug("R2ConcreteTarget read_register at %s "%(register))
+            registers = self.r2.cmdj('drtj all')
+        except Exception as e:
+            l.debug("R2ConcreteTarget read_register %s exception %s %s "%(register,type(e).__name__,e))
+            raise SimConcreteRegisterError("R2ConcreteTarget can't read register %s exception %s" % (register, e))
+
+        if register in registers:
+            return registers[register]
+        # when accessing xmm registers and ymm register gdb return a list of 4/8 32 bit values
+        # which need to be shifted appropriately to create a 128/256 bit value
+
+        # XMM
+        if register.startswith('xmm'):
+            return (registers[register + 'h'] << 64) + registers[register + 'l']
+
+        l.error('Unhandled register read of %s', register)
+
+    def write_register(self, register, value, **kwargs):
+        """
+        Writes a register to the target
+            :param str register:     The name of the register
+            :param int value:        int value written to be written register
+            :raise angr.errors.ConcreteRegisterError
+        """
+
+        # XMM/ST writes fail atm: https://github.com/radare/radare2/issues/13090
+        # Resolve some regs
+        if register in ['pc','sp','bp']:
+            l.debug('R2ConcreteTarget resolving %s',register)
+            register = self.r2.cmd('drn {}'.format(register)).strip()
+            l.debug('R2ConcreteTarget resolved to %s', register)
+
+        registers = self.r2.cmdj('drtj all')
+
+        #TODO: Implement xmm writes
+
+        if register not in registers:
+            error = "R2ConcreteTarget write_register unhandled reg name of {}".format(register)
+            l.error(error)
+            raise SimConcreteRegisterError(error)
+
+        l.debug("R2ConcreteTarget write_register at %s value %x "%(register,value))
+        self.r2.cmd('dr {}={}'.format(register, value))
+
+
+    def set_breakpoint(self,address, **kwargs):
+        """Inserts a breakpoint
+
+                :param optional bool hardware: Hardware breakpoint
+                :param optional bool temporary:  Tempory breakpoint
+                :param optional str regex:     If set, inserts breakpoints matching the regex
+                :param optional str condition: If set, inserts a breakpoint with the condition
+                :param optional int ignore_count: Amount of times the bp should be ignored
+                :param optional int thread:    Thread cno in which this breakpoints should be added
+                :raise angr.errors.ConcreteBreakpointError
+        """
+        l.debug("R2ConcreteTarget set_breakpoint at %x "%(address))
+        self.r2.cmd('db {}'.format(hex(address)))
+        if not any(x for x in self.r2.cmdj('dbj') if x['addr'] == address):
+            raise SimConcreteBreakpointError("R2ConcreteTarget failed to set_breakpoint at %x" % (address))
+
+    def remove_breakpoint(self, address, **kwargs):
+        l.debug("R2ConcreteTarget remove_breakpoint at %x "%(address))
+        self.r2.cmd('db-{}'.format(hex(address)))
+        if any(x for x in self.r2.cmdj('dbj') if x['addr'] == address):        
+            raise SimConcreteBreakpointError("R2ConcreteTarget failed to remove_breakpoint at %x" % (address))
+
+    def set_watchpoint(self,address, **kwargs):
+        """Inserts a watchpoint
+
+                :param address: The name of a variable or an address to watch
+                :param optional bool write:    Write watchpoint
+                :param optional bool read:     Read watchpoint
+                :raise angr.errors.ConcreteBreakpointError
+        """
+        l.debug("gdb target set_watchpoing at %x value"%(address))
+        res = self.target.set_watchpoint(address, **kwargs)
+        if res == -1:
+            raise SimConcreteBreakpointError("R2ConcreteTarget failed to set_breakpoint at %x" % (address))
+
+    def get_mappings(self):
+        """Returns the mmap of the concrete process
+        :return:
+        """
+
+        class MemoryMap:
+            """
+            Describing a memory range inside the concrete
+            process.
+            """
+            def __init__(self, start_address, end_address, offset, name):
+                self.start_address = start_address
+                self.end_address = end_address
+                self.offset = offset
+                self.name = name
+
+            def __str__(self):
+                my_str = "MemoryMap[start_address: 0x%x | end_address: 0x%x | name: %s" \
+                      % (self.start_address,
+                         self.end_address,
+                         self.name)
+
+                return my_str
+
+        l.debug("getting the vmmap of the concrete process")
+        mapping_output = self.target.protocols.memory.get_mappings()
+
+        mapping_output = mapping_output[1].split("\n")[4:]
+
+        vmmap = []
+
+        for map in mapping_output:
+            map = map.split(" ")
+
+            # removing empty entries
+            map = list(filter(lambda x: x not in ["\\t", "\\n", ''], map))
+
+            try:
+                map_start_address = map[0].replace("\\n", '')
+                map_start_address = map_start_address.replace("\\t", '')
+                map_start_address = int(map_start_address, 16)
+                map_end_address = map[1].replace("\\n", '')
+                map_end_address = map_end_address.replace("\\t", '')
+                map_end_address = int(map_end_address, 16)
+                offset = map[3].replace("\\n", '')
+                offset = offset.replace("\\t", '')
+                offset = int(offset, 16)
+                map_name = map[4].replace("\\n", '')
+                map_name = map_name.replace("\\t", '')
+                map_name = os.path.basename(map_name)
+                vmmap.append(MemoryMap(map_start_address, map_end_address, offset, map_name))
+            except (IndexError, ValueError):
+                l.debug("Can't process this vmmap entry")
+                pass
+
+        return vmmap
+
+    def is_running(self):
+
+        class TargetStates(IntEnum):
+            """
+            Enum copied from avatar target
+            A simple Enum for the different states a target can be in.
+            """
+            CREATED = 0x1
+            INITIALIZED = 0x2
+            STOPPED = 0x4
+            RUNNING = 0x8
+            SYNCING = 0x10
+            EXITED = 0x20
+            NOT_RUNNING = INITIALIZED | STOPPED
+
+        return self.target.get_status() == TargetStates.RUNNING
+
+    def stop(self):
+        self.target.stop()
+
+    def run(self):
+        """
+        Resume the execution of the target
+        :return:
+        """
+        if not self.is_running():
+            l.debug("gdb target run")
+            #pc = self.read_register('pc')
+            #print("Register before resuming: %#x" % pc)
+            self.target.cont()
+            self.target.wait()
+        else:
+            l.debug("gdb target is running!")
+
+    @property
+    def architecture(self):
+        return self.r2.cmdj('iAj')['bins'][0]['arch']
+
+    @property
+    def bits(self):
+        return self.r2.cmdj('iAj')['bins'][0]['bits']

--- a/tests/tests_r2_target_linux.py
+++ b/tests/tests_r2_target_linux.py
@@ -108,6 +108,26 @@ def test_r2_target_linux_x64_read_write_memory():
     
     r2db.exit()
 
+def test_r2_target_linux_x64_watchpoints():
+    r2 = r2pipe.open(binary_x64, ['-d'])
+    r2db = R2ConcreteTarget(r2)
+
+    proj = angr.Project(r2.cmdj('ij')['core']['file'], concrete_target=r2db, use_sim_procedures=True)
+    simgr = proj.factory.simulation_manager()
+    simgr.use_technique(angr.exploration_techniques.Symbion(find=[0x0040113c]))
+    simgr.run()
+
+    nose.tools.assert_true(len(simgr.found) == 1)
+    state = simgr.found[0]
+
+    # Test watching for memory read access
+    r2db.set_watchpoint(state.solver.eval(state.regs.rbp-0xa), write=True)
+
+    # TODO: Watchpoint in this manner is currently broken in r2: https://github.com/radare/radare2/issues/13123
+    # Update test once r2 fixes this.
+
+    r2db.exit()
+
 
 def run_all():
     functions = globals()

--- a/tests/tests_r2_target_linux.py
+++ b/tests/tests_r2_target_linux.py
@@ -1,0 +1,123 @@
+
+import logging
+#logging.basicConfig(level=logging.DEBUG)
+
+logger = logging.getLogger('tests_r2_target_linux')
+
+import os
+import sys
+from angr_targets import R2ConcreteTarget
+import nose
+import r2pipe
+
+import angr, claripy
+
+#
+# x86_64
+#
+
+binary_x64 = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                          os.path.join('..', '..', 'binaries','tests','x86_64','known_values_x64'))
+
+binary_x64_breakpoint = 0x004011fa
+
+rax = 0x3ec373b4667e84c0
+rbx = 0xa602acd4c227da1d
+rcx = 0x8807e4e63e154dbd
+rdx = 0x7644b4b3b2bd76ad
+rsi = 0x73b245d4fe9f7039
+rdi = 0xab648b4505db20b6
+r8  = 0xcdc3550dc8584425
+r9  = 0xe3efe87851d603f5
+r10 = 0x7c34483ec98d7bb7
+r11 = 0xb4b176ca868be1ed
+r12 = 0xf418c58fa13e485c
+r13 = 0x1803882a9c2c801a
+r14 = 0xecedb671e137e92f
+r15 = 0x9dce02118db26baa
+xmm0 = 0x43e6ca2beab80cd143defc418b1477ce
+st7  = 0x3ffee8e8276e6a138800
+
+#binary_x86 = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+#                                          os.path.join('..', '..', 'binaries','tests','i386','fauxware'))
+
+
+def test_r2_target_linux_x64_read_registers():
+    r2 = r2pipe.open(binary_x64, ['-d'])
+    r2db = R2ConcreteTarget(r2)
+
+    proj = angr.Project(r2.cmdj('ij')['core']['file'], concrete_target=r2db, use_sim_procedures=True)
+    simgr = proj.factory.simulation_manager()
+    simgr.use_technique(angr.exploration_techniques.Symbion(find=[binary_x64_breakpoint]))
+    simgr.run()
+
+    nose.tools.assert_true(len(simgr.found) == 1)
+    state = simgr.found[0]
+    
+    nose.tools.assert_true(state.solver.eval(state.regs.rax == rax))
+    nose.tools.assert_true(state.solver.eval(state.regs.rbx == rbx))
+    nose.tools.assert_true(state.solver.eval(state.regs.rcx == rcx))
+    nose.tools.assert_true(state.solver.eval(state.regs.rdx == rdx))
+    nose.tools.assert_true(state.solver.eval(state.regs.rsi == rsi))
+    nose.tools.assert_true(state.solver.eval(state.regs.rdi == rdi))
+    nose.tools.assert_true(state.solver.eval(state.regs.r8 == r8))
+    nose.tools.assert_true(state.solver.eval(state.regs.r9 == r9))
+    nose.tools.assert_true(state.solver.eval(state.regs.r10 == r10))
+    nose.tools.assert_true(state.solver.eval(state.regs.r11 == r11))
+    nose.tools.assert_true(state.solver.eval(state.regs.r12 == r12))
+    nose.tools.assert_true(state.solver.eval(state.regs.r13 == r13))
+    nose.tools.assert_true(state.solver.eval(state.regs.r14 == r14))
+    nose.tools.assert_true(state.solver.eval(state.regs.r15 == r15))
+    nose.tools.assert_true(state.solver.eval(state.regs.xmm0 == xmm0))
+    # TODO: For the moment, ST regs are not being sync'd to angr. Re-add this once they are being sync'd.
+    #nose.tools.assert_true(state.solver.eval(state.regs.st7 == st7))
+
+    r2db.exit()
+
+def test_r2_target_linux_x64_write_registers():
+    r2 = r2pipe.open(binary_x64, ['-d'])
+    r2db = R2ConcreteTarget(r2)
+    
+    new_value = 0x1212121245454545
+    r2db.write_register('rax', new_value)
+    nose.tools.assert_true(r2db.read_register('rax') == new_value)
+    r2db.exit()
+
+def test_r2_target_linux_x64_read_write_memory():
+    r2 = r2pipe.open(binary_x64, ['-d'])
+    r2db = R2ConcreteTarget(r2)
+
+    proj = angr.Project(r2.cmdj('ij')['core']['file'], concrete_target=r2db, use_sim_procedures=True)
+    simgr = proj.factory.simulation_manager()
+    simgr.use_technique(angr.exploration_techniques.Symbion(find=[binary_x64_breakpoint]))
+    simgr.run()
+
+    nose.tools.assert_true(len(simgr.found) == 1)
+    state = simgr.found[0]
+
+    # Pre-existing values in program
+    nose.tools.assert_true( state.mem[state.regs.rbp-0x16].string.concrete == b'Test string 2' )
+    nose.tools.assert_true( state.mem[0x00404030].string.concrete == b'Test string 1' )
+
+    # Write some stuff
+    new_string = b'This is my shiny new string. ZOMG!'
+    r2db.write_memory(0x00404030, new_string)
+
+    state.concrete.sync()
+    nose.tools.assert_true( state.mem[0x00404030].string.concrete == new_string )
+    
+    r2db.exit()
+
+
+def run_all():
+    functions = globals()
+    all_functions = dict(filter((lambda kv: kv[0].startswith('test_')), functions.items()))
+    for f in sorted(all_functions.keys()):
+        if hasattr(all_functions[f], '__call__'):
+            all_functions[f]()
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        globals()['test_' + sys.argv[1]]()
+    else:
+        run_all()


### PR DESCRIPTION
Some initial R2 functions. Keeping this as a PR for now for cognizance. Using gdb as an example, but not implementing a full Avatar2 framework.

Somewhat implemented through set/remove breakpoint at the moment.

The idea for how to use this would be to instantiate the R2Concrete class with an already instantiated r2 class. This allows for r2 to get set up however one wants, and then simply the hand the class itself off to angr when ready.

For example, my current tests look like this:

```python
  1 #!/usr/bin/env python3
  2
  3 import r2pipe
  4 from angr_targets import R2ConcreteTarget
  5
  6 r2 = r2pipe.open('/bin/ls', ['-d'])
  7 r2.cmd('')
  8 r2.cmd('')
  9 r2.cmd('')
 10 r2db = R2ConcreteTarget(r2)
 11
 12 sp = r2.cmdj('drj')['rsp']
 13 test_str = 'this_is_a_test'
 14
 15 print('Testing read/write ... ', flush=True, end='')
 16 r2db.write_memory(sp, test_str)
 17 assert r2db.read_memory(sp, len(test_str)) == test_str
 18 print('[ OK ]')
 19
 20
 21 print('Testing read register ... ', flush=True, end='')
 22 assert r2db.read_register('sp') == sp
 23 print('[ OK ]')
 24
 25 print('Testing write register ... ', flush=True, end='')
 26 r2db.write_register('rax', 0x12345)
 27 assert r2db.read_register('rax') == 0x12345
 28 print('[ OK ]')
 29
 30 print('Testing set breakpoint ... ', flush=True, end='')
 31 addr = r2db.read_register('rip')
 32 r2db.set_breakpoint(addr) # This checks that it gets set internally and excepts out
 33 print('[ OK ]')
 34
 35 print('Testing remove breakpoint ... ', flush=True, end='')
 36 r2db.remove_breakpoint(addr) # This checks that it gets set internally and excepts out
 37 print('[ OK ]')
```